### PR TITLE
Added `setValue` method

### DIFF
--- a/dist/am-date-picker.directive.js
+++ b/dist/am-date-picker.directive.js
@@ -3,7 +3,7 @@
 
     angular
         .module('am.date-picker')
-        .directive('amDatePicker', amDatePicker)
+        .directive('amDatePicker', amDatePicker);
 
     function amDatePicker() {
         return {
@@ -50,6 +50,12 @@
         amDatePicker.openPicker = openPicker;
 
         amDatePicker.ngModelCtrl = null;
+
+        amDatePicker.setValue = function setValue(value) {
+            amDatePicker.ngModelCtrl.$setViewValue(value);
+            amDatePicker.ngModelCtrl.$setTouched();
+            render();
+        };
 
         $scope.$watch("amDatePicker.minDate", function (newValue, oldValue) {
             var date = amDatePicker.ngModelCtrl.$viewValue,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,7 +66,7 @@ gulp.task('watch', function() {
 
 
 gulp.task('default', [
-    //'watch',
+    'watch',
     'images',
     'less',
     'scripts',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "_spec": "am-date-picker",
   "_where": "/var/www/panel",
   "dependencies": {
-    "angular": "^1.6.1"
+    "angular": "^1.6.1",
+    "moment": "^2.19.1"
   },
   "description": "Simple datepicker based on angular material framework",
   "devDependencies": {

--- a/src/js/am-date-picker.dialog.js
+++ b/src/js/am-date-picker.dialog.js
@@ -57,6 +57,7 @@
         }
 
         function cancel() {
+            dialog.onClose();
             $mdDialog.cancel();
         }
 
@@ -99,6 +100,7 @@
         }
 
         function hide() {
+            dialog.onClose();
             $mdDialog.hide(dialog.dateMoment.toDate());
         }
 

--- a/src/js/am-date-picker.directive.js
+++ b/src/js/am-date-picker.directive.js
@@ -3,7 +3,7 @@
 
     angular
         .module('am.date-picker')
-        .directive('amDatePicker', amDatePicker)
+        .directive('amDatePicker', amDatePicker);
 
     function amDatePicker() {
         return {

--- a/src/js/am-date-picker.directive.js
+++ b/src/js/am-date-picker.directive.js
@@ -33,6 +33,8 @@
                 popupDateFormat: '@?amPopupDateFormat',
                 showInputIcon: '=?amShowInputIcon',
                 todayButton: '@?amTodayButton',
+                onOpen: '&',
+                onClose: '&'
             },
             templateUrl: 'am-date-picker.html'
         };
@@ -104,6 +106,7 @@
         }
 
         function openPicker(ev) {
+            amDatePicker.onOpen();
             $mdDialog.show({
                 bindToController: true,
                 controller: 'amDatePickerDialogCtrl',
@@ -120,7 +123,8 @@
                     locale: amDatePicker.locale,
                     popupDateFormat: amDatePicker.popupDateFormat,
                     prevIcon: amDatePicker.prevIcon,
-                    todayButton: amDatePicker.todayButton
+                    todayButton: amDatePicker.todayButton,
+                    onClose: amDatePicker.onClose
                 },
                 parent: angular.element(document.body),
                 targetEvent: ev,

--- a/src/js/am-date-picker.directive.js
+++ b/src/js/am-date-picker.directive.js
@@ -49,6 +49,12 @@
 
         amDatePicker.ngModelCtrl = null;
 
+        amDatePicker.setValue = function setValue(value) {
+            amDatePicker.ngModelCtrl.$setViewValue(value);
+            amDatePicker.ngModelCtrl.$setTouched();
+            render();
+        };
+
         $scope.$watch("amDatePicker.minDate", function (newValue, oldValue) {
             var date = amDatePicker.ngModelCtrl.$viewValue,
                 dateMoment = moment(date);


### PR DESCRIPTION
As in title, this PR adds a `setValue` method to `AmDatePickerController` which allows changing a value from JS script. It will help in a case when a developer wants to update the value using JS script instead of mocking clicking the calendar.

@ares828, for the future – if you modify the code, update the sources files instead of dist files. When you are changing the dist, source files aren't updated and it may cause the changes are losing. I fixed it in 56ad6a3.

If you want to test your changes live, you should use [`npm link`](https://docs.npmjs.com/cli/link) command in order to connect the project repository and this package and the `gulp default` task for refreshing the `dist/` directory automatically.